### PR TITLE
Numba deprecation warnings

### DIFF
--- a/shap/explainers/_exact.py
+++ b/shap/explainers/_exact.py
@@ -175,7 +175,7 @@ class Exact(Explainer):
             "clustering": getattr(self.masker, "clustering", None)
         }
 
-@jit
+@jit(nopython=False)
 def _compute_grey_code_row_values(row_values, mask, inds, outputs, shapley_coeff, extended_delta_indexes, noop_code):
     set_size = 0
     M = len(inds)
@@ -201,7 +201,7 @@ def _compute_grey_code_row_values(row_values, mask, inds, outputs, shapley_coeff
             else:
                 row_values[j] -= out * off_coeff
 
-@jit
+@jit(nopython=False)
 def _compute_grey_code_row_values_st(row_values, mask, inds, outputs, shapley_coeff, extended_delta_indexes, noop_code):
     set_size = 0
     M = len(inds)

--- a/shap/explainers/_partition.py
+++ b/shap/explainers/_partition.py
@@ -672,7 +672,7 @@ def output_indexes_len(output_indexes):
     elif not isinstance(output_indexes, str):
         return len(output_indexes)
 
-@jit
+@jit(nopython=False)
 def lower_credit(i, value, M, values, clustering):
     if i < M:
         values[i] += value

--- a/shap/links.py
+++ b/shap/links.py
@@ -1,22 +1,22 @@
 import numpy as np
 import numba
 
-@numba.jit
+@numba.jit(nopython=False)
 def identity(x):
     """ A no-op link function.
     """
     return x
-@numba.jit
+@numba.jit(nopython=False)
 def _identity_inverse(x):
     return x
 identity.inverse = _identity_inverse
 
-@numba.jit
+@numba.jit(nopython=False)
 def logit(x):
     """ A logit link function useful for going from probability units to log-odds units.
     """
     return np.log(x/(1-x))
-@numba.jit
+@numba.jit(nopython=False)
 def _logit_inverse(x):
     return 1/(1+np.exp(-x))
 logit.inverse = _logit_inverse

--- a/shap/maskers/_image.py
+++ b/shap/maskers/_image.py
@@ -171,7 +171,7 @@ class Image(Masker):
             kwargs["shape"] = s.load("shape")
         return kwargs
 
-@jit
+@jit(nopython=False)
 def _jit_build_partition_tree(xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, total_zwidth, M, clustering, q):
     """ This partitions an image into a herarchical clustering based on axis-aligned splits.
     """

--- a/shap/maskers/_tabular.py
+++ b/shap/maskers/_tabular.py
@@ -182,7 +182,7 @@ class Tabular(Masker):
             kwargs["clustering"] = s.load("clustering")
         return kwargs
 
-@jit
+@jit(nopython=False)
 def _single_delta_mask(dind, masked_inputs, last_mask, data, x, noop_code):
     if dind == noop_code:
         pass
@@ -193,7 +193,7 @@ def _single_delta_mask(dind, masked_inputs, last_mask, data, x, noop_code):
         masked_inputs[:, dind] = x[dind]
         last_mask[dind] = True
 
-@jit
+@jit(nopython=False)
 def _delta_masking(masks, x, curr_delta_inds, varying_rows_out,
                    masked_inputs_tmp, last_mask, data, variants, masked_inputs_out, noop_code):
     """ Implements the special (high speed) delta masking API that only flips the positions we need to.

--- a/shap/utils/_clustering.py
+++ b/shap/utils/_clustering.py
@@ -31,7 +31,7 @@ def partition_tree_shuffle(indexes, index_mask, partition_tree):
     M = len(index_mask)
     #switch = np.random.randn(M) < 0
     _pt_shuffle_rec(partition_tree.shape[0]-1, indexes, index_mask, partition_tree, M, 0)
-@jit
+@jit(nopython=False)
 def _pt_shuffle_rec(i, indexes, index_mask, partition_tree, M, pos):
     if i < 0:
         # see if we should include this index in the ordering
@@ -50,7 +50,7 @@ def _pt_shuffle_rec(i, indexes, index_mask, partition_tree, M, pos):
         pos = _pt_shuffle_rec(left, indexes, index_mask, partition_tree, M, pos)
     return pos
 
-@jit
+@jit(nopython=False)
 def delta_minimization_order(all_masks, max_swap_size=100, num_passes=2):
     order = np.arange(len(all_masks))
     for _ in range(num_passes):
@@ -59,13 +59,13 @@ def delta_minimization_order(all_masks, max_swap_size=100, num_passes=2):
                 if _reverse_window_score_gain(all_masks, order, i, length) > 0:
                     _reverse_window(order, i, length)
     return order
-@jit
+@jit(nopython=False)
 def _reverse_window(order, start, length):
     for i in range(length // 2):
         tmp = order[start + i]
         order[start + i] = order[start + length - i - 1]
         order[start + length - i - 1] = tmp
-@jit
+@jit(nopython=False)
 def _reverse_window_score_gain(masks, order, start, length):
     forward_score = _mask_delta_score(masks[order[start - 1]], masks[order[start]]) + \
                     _mask_delta_score(masks[order[start + length-1]], masks[order[start + length]])
@@ -73,7 +73,7 @@ def _reverse_window_score_gain(masks, order, start, length):
                     _mask_delta_score(masks[order[start]], masks[order[start + length]])
     
     return forward_score - reverse_score
-@jit
+@jit(nopython=False)
 def _mask_delta_score(m1, m2):
     return (m1 ^ m2).sum()
 

--- a/shap/utils/_masked_model.py
+++ b/shap/utils/_masked_model.py
@@ -288,7 +288,7 @@ def _convert_delta_mask_to_full(masks, full_masks):
             full_masks[i,masks[masks_pos]] = ~full_masks[i,masks[masks_pos]]
         masks_pos += 1
 
-#@jit # TODO: figure out how to jit this function, or most of it
+#@jit(nopython=False) # TODO: figure out how to jit this function, or most of it
 def _build_delta_masked_inputs(masks, batch_positions, num_mask_samples, num_varying_rows, delta_indexes,
                                varying_rows, args, masker, variants, variants_column_sums):
     all_masked_inputs = [[] for a in args]
@@ -359,7 +359,7 @@ def _build_fixed_output(averaged_outs, last_outs, outputs, batch_positions, vary
     else:
         _build_fixed_multi_output(averaged_outs, last_outs, outputs, batch_positions, varying_rows, num_varying_rows, link, linearizing_weights)
 
-@jit # we can't use this when using a custom link function...
+@jit(nopython=False) # we can't use this when using a custom link function...
 def _build_fixed_single_output(averaged_outs, last_outs, outputs, batch_positions, varying_rows, num_varying_rows, link, linearizing_weights):
     # here we can assume that the outputs will always be the same size, and we need
     # to carry over evaluation outputs
@@ -381,7 +381,7 @@ def _build_fixed_single_output(averaged_outs, last_outs, outputs, batch_position
         else:
             averaged_outs[i] = averaged_outs[i-1]
 
-@jit
+@jit(nopython=False)
 def _build_fixed_multi_output(averaged_outs, last_outs, outputs, batch_positions, varying_rows, num_varying_rows, link, linearizing_weights):
     # here we can assume that the outputs will always be the same size, and we need
     # to carry over evaluation outputs
@@ -424,7 +424,7 @@ def make_masks(cluster_matrix):
 
     return mask_matrix
 
-@jit
+@jit(nopython=False)
 def _init_masks(cluster_matrix, M, indices_row_pos, indptr):
     pos = 0
     for i in range(2 * M - 1):
@@ -435,7 +435,7 @@ def _init_masks(cluster_matrix, M, indices_row_pos, indptr):
         indptr[i+1] = pos
         indices_row_pos[i] = indptr[i]
 
-@jit
+@jit(nopython=False)
 def _rec_fill_masks(cluster_matrix, indices_row_pos, indptr, indices, M, ind):
     pos = indices_row_pos[ind]
 


### PR DESCRIPTION
Trying to remove as many of these as possible:

```
/home/runner/work/evalml/evalml/test_python/lib/python3.8/site-packages/shap/maskers/_image.py:175: NumbaDeprecationWarning: The 'nopython' keyword argument was not supplied to the 'numba.jit' decorator. The implicit default value for this argument is currently False, but it will be changed to True in Numba 0.59.0. See https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit for details.
  def _jit_build_partition_tree(xmin, xmax, ymin, ymax, zmin, zmax, total_ywidth, total_zwidth, M, clustering, q):
/home/runner/work/evalml/evalml/test_python/lib/python3.8/site-packages/shap/explainers/_partition.py:676: NumbaDeprecationWarning: The 'nopython' keyword argument was not supplied to the 'numba.jit' decorator. The implicit default value for this argument is currently False, but it will be changed to True in Numba 0.59.0. See https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit for details.
  def lower_credit(i, value, M, values, clustering):
The 'nopython' keyword argument was not supplied to the 'numba.jit' decorator. The implicit default value for this argument is currently False, but it will be changed to True in Numba 0.59.0. See https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit for details.
The 'nopython' keyword argument was not supplied to the 'numba.jit' decorator. The implicit default value for this argument is currently False, but it will be changed to True in Numba 0.59.0. See https://numba.readthedocs.io/en/stable/reference/deprecation.html#deprecation-of-object-mode-fall-back-behaviour-when-using-jit for details.
```